### PR TITLE
Add support for Node.js `Readable` stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,16 @@ npm install read-next-line
 ```
 
 ## Compatibility
-**read-next-line** is a hybrid ECMAScript Module (ESM) with CommonJS backwards compatibility support. Designed to work with Works seamlessly with [Node.js Web Streams API](https://nodejs.org/api/webstreams.html#web-streams-api) or [Streams_API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) in the browser.
+
+**read-next-line** is a hybrid JavaScript module, supporting:
+- ECMAScript Module (ESM)
+- CommonJS backwards compatibility support
+
+Designed to work with Works seamlessly with either:
+- [Node.js Readable streams](https://nodejs.org/api/stream.html#readable-streams)
+- [Node.js Web Streams API](https://nodejs.org/api/webstreams.html#web-streams-api)
+- [Streams-API](https://developer.mozilla.org/docs/Web/API/Streams_API) in the browser
+
 Compatible with modern web browsers or Node.js ≥ 18.
 
 ## Usage
@@ -49,7 +58,7 @@ In CommonJS projects use:
 const {ReadNextLine} = require('read-next-line');
 ```
 
-Using **read-next-line** to read lines of text of a binary [ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream):
+Using **read-next-line** to read lines of text of a binary [ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream) or [Node.js Readable streams](https://nodejs.org/api/stream.html#readable-streams):
 ```js
 async function processStream(stream) {
 	const reader = new ReadNextLine(stream);
@@ -91,14 +100,8 @@ new StreamLineReader(stream: ReadableStream<Uint8Array>);
 
 - **`readLine(): Promise<string | null>`**
 	- Reads the next line from the stream. Returns `null` if the stream ends.
-
-## How It Works
-
-`StreamLineReader`:
-
-1. Reads lines directly from a `ReadableStream` using a `TextDecoderStream` to decode binary data into text.
-2. Splits the decoded text by Unix (`\n`) or Windows (`\r\n`) line endings.
-3. Buffers incomplete lines for the next read operation.
+- **`release(): void`**
+    - Release the internal [Reader](https://developer.mozilla.org/docs/Web/API/ReadableStreamDefaultReader/releaseLock).
 
 
 ## License

--- a/test/test.js
+++ b/test/test.js
@@ -1,62 +1,71 @@
 import * as chai from 'chai';
 import chaiString from 'chai-string';
-import { fileURLToPath } from 'node:url';
+import {fileURLToPath} from 'node:url';
 import path from 'node:path';
 import {ReadNextLine} from '../lib/read-next-line.js';
-import {createReadableStreamFromFile, createStreamFromString} from "./util.js";
+import {createWebReadableStreamFromFile, createStreamFromString, createNodeReadableStreamFromFile} from "./util.js";
 
 chai.use(chaiString);
 
-const { expect } = chai;
+const {expect} = chai;
 
 // Convert `import.meta.url` to a file path
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 describe('ReadNextLine', () => {
-    // Helper function to create a ReadableStream from a string
+	// Helper function to create a ReadableStream from a string
 
-	describe('Handle line endings', ()=> {
+	describe('Handle line endings', () => {
 		it('should handle Unix line ending: LF', async () => {
 			const input = 'line1\nline2\nline3\n';
 			const stream = createStreamFromString(input);
 			const reader = new ReadNextLine(stream);
+			try {
+				expect(await reader.readLine()).to.equal('line1');
+				expect(await reader.readLine()).to.equal('line2');
+				expect(await reader.readLine()).to.equal('line3');
+				expect(await reader.readLine()).to.be.null;
+			} finally {
+				reader.release();
+			}
 
-			expect(await reader.readLine()).to.equal('line1');
-			expect(await reader.readLine()).to.equal('line2');
-			expect(await reader.readLine()).to.equal('line3');
-			expect(await reader.readLine()).to.be.null;
 		});
 
 		it('should handle Windows line ending: CR LF', async () => {
 			const input = 'line1\r\nline2\r\nline3\r\n';
 			const stream = createStreamFromString(input);
 			const reader = new ReadNextLine(stream);
+			try {
+				expect(await reader.readLine()).to.equal('line1');
+				expect(await reader.readLine()).to.equal('line2');
+				expect(await reader.readLine()).to.equal('line3');
+				expect(await reader.readLine()).to.be.null;
+			} finally {
+				reader.release();
+			}
 
-			expect(await reader.readLine()).to.equal('line1');
-			expect(await reader.readLine()).to.equal('line2');
-			expect(await reader.readLine()).to.equal('line3');
-			expect(await reader.readLine()).to.be.null;
 		});
 
 		it('should handle a stream with an incomplete line at the end', async () => {
 			const input = 'line1\nline2\nincomplete';
 			const stream = createStreamFromString(input);
 			const reader = new ReadNextLine(stream);
-
-			expect(await reader.readLine()).to.equal('line1');
-			expect(await reader.readLine()).to.equal('line2');
-			expect(await reader.readLine()).to.equal('incomplete');
-			expect(await reader.readLine()).to.be.null;
+			try {
+				expect(await reader.readLine()).to.equal('line1');
+				expect(await reader.readLine()).to.equal('line2');
+				expect(await reader.readLine()).to.equal('incomplete');
+				expect(await reader.readLine()).to.be.null;
+			} finally {
+				reader.release();
+			}
 		});
 
 	});
 
-	describe('Text encoding', () => {
-
-		async function countLines(sample, nrOfLinex, startsWith) {
-			const readableStream = await createReadableStreamFromFile(path.join(__dirname, 'samples', sample));
-			const reader = new ReadNextLine(readableStream);
+	async function countLines(stream, nrOfLinex, startsWith) {
+		const reader = new ReadNextLine(stream);
+		try {
 			let line;
 			let lineCount = 0;
 			while ((line = await reader.readLine()) !== null) {
@@ -66,48 +75,85 @@ describe('ReadNextLine', () => {
 				++lineCount;
 			}
 			expect(lineCount).to.equal(nrOfLinex);
+		} finally {
+			reader.release();
+		}
+	}
+
+	const startsWith = 'Lorem ipsum odor amet, consectetuer adipiscing elit.'
+
+	describe('Text encoding from Web ReadableStream', () => {
+
+		async function countLinesFromWebStream(sample, nrOfLinex, startsWith) {
+			const webStream = await createWebReadableStreamFromFile(path.join(__dirname, 'samples', sample));
+			return countLines(webStream, nrOfLinex, startsWith);
 		}
 
-		const startsWith = 'Lorem ipsum odor amet, consectetuer adipiscing elit.'
-
 		it('should decode UTF-8', async () => {
-			await countLines('lorem-ipsem.utf-8.txt', 999, startsWith)
+			await countLinesFromWebStream('lorem-ipsem.utf-8.txt', 999, startsWith)
 		});
 
 		it('should decode UTF-8 with BOM', async () => {
-			await countLines('lorem-ipsem.utf-8-bom.txt', 999, startsWith)
+			await countLinesFromWebStream('lorem-ipsem.utf-8-bom.txt', 999, startsWith)
 		});
-	})
+	});
 
-    it('should handle an empty stream', async () => {
-        const input = '';
-        const stream = createStreamFromString(input);
-        const reader = new ReadNextLine(stream);
+	describe('Text encoding from Node.js Readable', () => {
 
-        expect(await reader.readLine()).to.be.null;
-    });
+		async function countLinesFromNodeStream(sample, nrOfLinex, startsWith) {
+			const nodeReadable = await createNodeReadableStreamFromFile(path.join(__dirname, 'samples', sample));
+			return countLines(nodeReadable, nrOfLinex, startsWith);
+		}
 
-    it('should handle a stream with a single line and no newline', async () => {
-        const input = 'singleLine';
-        const stream = createStreamFromString(input);
-        const reader = new ReadNextLine(stream);
+		it('should decode UTF-8', async () => {
+			await countLinesFromNodeStream('lorem-ipsem.utf-8.txt', 999, startsWith)
+		});
 
-        expect(await reader.readLine()).to.equal('singleLine');
-        expect(await reader.readLine()).to.be.null;
-    });
+		it('should decode UTF-8 with BOM', async () => {
+			await countLinesFromNodeStream('lorem-ipsem.utf-8-bom.txt', 999, startsWith)
+		});
+	});
 
-    it('should handle a stream with multiple consecutive newlines', async () => {
-        const input = 'line1\n\nline2\n\n\nline3\n';
-        const stream = createStreamFromString(input);
-        const reader = new ReadNextLine(stream);
 
-        expect(await reader.readLine()).to.equal('line1');
-        expect(await reader.readLine()).to.equal('');
-        expect(await reader.readLine()).to.equal('line2');
-        expect(await reader.readLine()).to.equal('');
-        expect(await reader.readLine()).to.equal('');
-        expect(await reader.readLine()).to.equal('line3');
-        expect(await reader.readLine()).to.be.null;
-    });
+
+	it('should handle an empty stream', async () => {
+		const input = '';
+		const stream = createStreamFromString(input);
+		const reader = new ReadNextLine(stream);
+		try {
+			expect(await reader.readLine()).to.be.null;
+		} finally {
+			reader.release();
+		}
+	});
+
+	it('should handle a stream with a single line and no newline', async () => {
+		const input = 'singleLine';
+		const stream = createStreamFromString(input);
+		const reader = new ReadNextLine(stream);
+		try {
+			expect(await reader.readLine()).to.equal('singleLine');
+			expect(await reader.readLine()).to.be.null;
+		} finally {
+			reader.release();
+		}
+	});
+
+	it('should handle a stream with multiple consecutive newlines', async () => {
+		const input = 'line1\n\nline2\n\n\nline3\n';
+		const stream = createStreamFromString(input);
+		const reader = new ReadNextLine(stream);
+		try {
+			expect(await reader.readLine()).to.equal('line1');
+			expect(await reader.readLine()).to.equal('');
+			expect(await reader.readLine()).to.equal('line2');
+			expect(await reader.readLine()).to.equal('');
+			expect(await reader.readLine()).to.equal('');
+			expect(await reader.readLine()).to.equal('line3');
+			expect(await reader.readLine()).to.be.null;
+		} finally {
+			reader.release();
+		}
+	});
 
 });

--- a/test/util.js
+++ b/test/util.js
@@ -12,9 +12,13 @@ export function createStreamFromString(input) {
 	});
 }
 
-export async function createReadableStreamFromFile(filePath) {
+export async function createNodeReadableStreamFromFile(filePath) {
 	const fileHandle = await fs.open(filePath, 'r');
-	const fileStream = fileHandle.createReadStream();
+	return fileHandle.createReadStream();
+}
+
+export async function createWebReadableStreamFromFile(filePath) {
+	const fileStream = await createNodeReadableStreamFromFile(filePath);
 
 	// Wrap the Node.js stream in a Web Streams API ReadableStream
 	return new ReadableStream ({


### PR DESCRIPTION
Add support for [Node.js Readable streams](https://nodejs.org/api/stream.html#readable-streams).
Automatically detect the correct stream format.